### PR TITLE
[FIX] : 배포 시 JSON파일 읽을 수 없는 문제 수정

### DIFF
--- a/be/sidedish-be/src/main/java/com/codesquad/sidedish/utils/SampleDataFactory.java
+++ b/be/sidedish-be/src/main/java/com/codesquad/sidedish/utils/SampleDataFactory.java
@@ -57,9 +57,7 @@ public class SampleDataFactory {
         objectMapper.setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE);
 
         try {
-            File file = new ClassPathResource(jsonFilePath).getFile();
-
-            return objectMapper.readValue(file, typeReference);
+            return objectMapper.readValue(new ClassPathResource(jsonFilePath).getInputStream(), typeReference);
         } catch (IOException e) {
             throw new IllegalStateException("경로가 올바르지 않습니다. 경로: " + jsonFilePath, e);
         }

--- a/be/sidedish-be/src/main/java/com/codesquad/sidedish/utils/SampleDataFactory.java
+++ b/be/sidedish-be/src/main/java/com/codesquad/sidedish/utils/SampleDataFactory.java
@@ -1,15 +1,16 @@
 package com.codesquad.sidedish.utils;
 
+import com.codesquad.sidedish.web.sidedish.DTO.DetailDTO;
 import com.codesquad.sidedish.web.sidedish.DTO.ItemDTO;
 import com.codesquad.sidedish.web.sidedish.DTO.SidedishDTO;
-import com.codesquad.sidedish.web.sidedish.DTO.DetailDTO;
+import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import org.springframework.core.io.ClassPathResource;
 
-import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -56,10 +57,12 @@ public class SampleDataFactory {
         ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE);
 
-        try {
-            return objectMapper.readValue(new ClassPathResource(jsonFilePath).getInputStream(), typeReference);
+        try (InputStream is = new ClassPathResource(jsonFilePath).getInputStream()) {
+            return objectMapper.readValue(is, typeReference);
+        } catch (JsonParseException e) {
+            throw new IllegalStateException("Json파일 파싱 중 에러 발생. jsonFilePath: " + jsonFilePath, e);
         } catch (IOException e) {
-            throw new IllegalStateException("경로가 올바르지 않습니다. 경로: " + jsonFilePath, e);
+            throw new IllegalStateException("파일 읽는 중 에러 발생. jsonFilePath: " + jsonFilePath, e);
         }
     }
 }


### PR DESCRIPTION
ClassPathResource 사용 시 URL이 File프로토콜을 사용하는지 확인한다.
하지만 executable jar로 실행 시, URL이 jar:file:로 되어 file프로토콜로
인식하지 못한다. 따라서 InputStream으로 수정.
[참고](https://sonegy.wordpress.com/2015/07/23/spring-boot-executable-jar%EC%97%90%EC%84%9C-file-resource-%EC%B2%98%EB%A6%AC/)